### PR TITLE
Try to add a "/players" command to factorio part of the bridge

### DIFF
--- a/src/platforms/factorio.rs
+++ b/src/platforms/factorio.rs
@@ -167,7 +167,7 @@ fn process_log(new_contents: &str, incoming_tx: &mut mpsc::Sender<IncomingMessag
                     }
                 },
                 "PLAYERLIST" => {
-                    let txt = contents.split(';')
+                    let list = contents.split(';')
                             .map(|player| {
                                 let (name, mut surface) = player.split_once(' ').unwrap();
                                 // surface can be Phoebe, nauvis, Nauvis Orbit, "detached nauvis" ...
@@ -186,6 +186,7 @@ fn process_log(new_contents: &str, incoming_tx: &mut mpsc::Sender<IncomingMessag
                             })
                             .collect::<Vec<_>>()
                             .join(", ");
+                    let txt = format!("Online players: {list}");
                     let msg = IncomingMessage {
                         channel_id: None,
                         user_id: None,

--- a/src/platforms/factorio.rs
+++ b/src/platforms/factorio.rs
@@ -54,7 +54,7 @@ impl ChatPlatform for Factorio {
             select! {
                 Some(msg) = outgoing_message_rx.recv() => {
                     let cmd;
-                    if msg.source_msg.contents.starts_with("/players ") || msg.source_msg.contents == "/players" {
+                    if msg.source_msg.contents.starts_with("!players ") || msg.source_msg.contents == "!players" {
                         cmd = String::from("/bridge-player-list");
                     } else {
                         let user_text = match msg.source_msg.user_name {

--- a/src/platforms/factorio.rs
+++ b/src/platforms/factorio.rs
@@ -172,13 +172,19 @@ fn process_log(new_contents: &str, incoming_tx: &mut mpsc::Sender<IncomingMessag
                                 // surface can be Phoebe, nauvis, Nauvis Orbit, "detached nauvis" ...
 
                                 // for some reason nauvis is lowercase, this fixes that
+                                let mut isdetached = false;
+
+                                if surface.starts_with("detached") {
+                                    surface = surface.split_once(' ').unwrap().1;
+                                    isdetached = true;
+                                }
+
                                 if surface == "nauvis" {
                                     surface = "Nauvis";
                                 }
 
-                                if surface.starts_with("detached") {
-                                    let viewedsurface = surface.split_once(' ').unwrap().1;
-                                    format!("{name} is looking at {viewedsurface}")
+                                if isdetached {
+                                    format!("{name} is looking at {surface}")
                                 } else {
                                     format!("{name} is on {surface}")
                                 }

--- a/src/platforms/factorio.rs
+++ b/src/platforms/factorio.rs
@@ -170,14 +170,19 @@ fn process_log(new_contents: &str, incoming_tx: &mut mpsc::Sender<IncomingMessag
                     let txt = contents.split(';')
                             .map(|player| {
                                 let (name, mut surface) = player.split_once(' ').unwrap();
-                                // surface can be Phoebe, nauvis, Nauvis Orbit, ...
+                                // surface can be Phoebe, nauvis, Nauvis Orbit, "detached nauvis" ...
 
                                 // for some reason nauvis is lowercase, this fixes that
                                 if surface == "nauvis" {
                                     surface = "Nauvis";
                                 }
 
-                                format!("{name} is on {surface}")
+                                if surface.starts_with("detached") {
+                                    let viewedsurface = surface.split_once(' ').unwrap().1;
+                                    format!("{name} is looking at {viewedsurface}")
+                                } else {
+                                    format!("{name} is on {surface}")
+                                }
                             })
                             .collect::<Vec<_>>()
                             .join(", ");

--- a/src/platforms/factorio.rs
+++ b/src/platforms/factorio.rs
@@ -53,9 +53,8 @@ impl ChatPlatform for Factorio {
         loop {
             select! {
                 Some(msg) = outgoing_message_rx.recv() => {
-                    let cmd;
-                    if msg.source_msg.contents.starts_with("!players ") || msg.source_msg.contents == "!players" {
-                        cmd = String::from("/bridge-player-list");
+                    let cmd = if msg.source_msg.contents.starts_with("!players ") || msg.source_msg.contents == "!players" {
+                        String::from("/bridge-player-list")
                     } else {
                         let user_text = match msg.source_msg.user_name {
                             Some(name) => match msg.source_msg.user_color {
@@ -67,8 +66,8 @@ impl ChatPlatform for Factorio {
                             None => msg.content.to_string()
                         };
 
-                        cmd = format!("/puppet [{}] {user_text}", msg.source_platform_name);
-                    }
+                        format!("/puppet [{}] {user_text}", msg.source_platform_name)
+                    };
 
                     if let Err(err) = rcon_client.cmd(&cmd).await {
                         error!("Could not send message to server: {err}");

--- a/src/platforms/factorio.rs
+++ b/src/platforms/factorio.rs
@@ -166,6 +166,16 @@ fn process_log(new_contents: &str, incoming_tx: &mut mpsc::Sender<IncomingMessag
                     }
                 },
                 "PLAYERLIST" => {
+                    if contents.is_empty() {
+                        let msg = IncomingMessage {
+                            channel_id: None,
+                            user_id: None,
+                            user_name: None,
+                            contents: "No players online".to_owned(),
+                            user_color: None,
+                        };
+                        return incoming_tx.blocking_send(msg).unwrap();
+                    }
                     let list = contents.split(';')
                             .map(|player| {
                                 let (name, mut surface) = player.split_once(' ').unwrap();


### PR DESCRIPTION
It invokes `/bridge-player-list`. Needs a patch to the mod:
```diff
diff --git a/supabridge-notifier/control.lua b/../supabridge-notifier/control.lua
index 755377a..1dc04f8 100644
--- a/supabridge-notifier/control.lua
+++ b/../supabridge-notifier/control.lua
@@ -63,3 +63,24 @@ commands.add_command("puppet", "Admin command for puppeting", function(command_d
         end
     end
 end)
+
+commands.add_command("bridge-player-list", "Admin command for listing players", function(command_data)
+    if command_data.player_index then
+        game.player.print("This command can only be used from the server console")
+    else
+        local list = ""
+        local sep = ""
+        for i, p in pairs(game.players) do
+            if p.connected then
+                if p.character == nil then
+                    list = list .. sep .. p.name .. " detached " .. p.surface.name
+                else
+                    list = list .. sep .. p.name .. " " .. p.surface.name
+                end
+                sep = ";"
+            end
+        end
+        append_line("PLAYERLIST", list)
+        -- PLAYERLIST mm2pl nauvis;boring_nick detached
+    end
+end)
```

It compiles and I hope that it works because I cannot test it